### PR TITLE
REXML version update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.3)
+    rexml (>=3.3.6)
       strscan
     rouge (4.3.0)
     safe_yaml (1.0.5)


### PR DESCRIPTION
VANTA Warning: REXML needs to be >=3.3.6. Gemlock file was updated accordingly.